### PR TITLE
Test case for #32

### DIFF
--- a/test/corpus/sections.txt
+++ b/test/corpus/sections.txt
@@ -107,3 +107,22 @@ with whitespaces
    (strong)))
  (section
    (title)))
+
+
+==================
+Section edge cases
+==================
+
+1. A section with a number
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+V. A section with a roman number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+---
+
+
+(document
+  (section (title))
+  (section (title)))


### PR DESCRIPTION
I'm still trying to understand how Tree-sitter-rst works.

I've tried to do

```diff
  _underline_section: $ => seq(
+    optional(seq($._numeric_bullet, ' ')),
     alias($._line, $.title),
     alias($._underline, 'adornment'),
  )
```

But unfortunately that seem to affect enumerated list parsing as well,
and it's unclear to me how to either tweak a precedence, or try to have
the parser backtracks