### PR TITLE
Fix block quote marker seen as adornment

### DIFF
--- a/src/tree_sitter_rst/parser.c
+++ b/src/tree_sitter_rst/parser.c
@@ -292,6 +292,9 @@ bool parse_underline(RSTScanner* scanner)
   }
 
   if (underline_length >= 1 && valid_symbols[T_UNDERLINE]) {
+    if ((underline_length == 2) && (adornment == ':')){
+      return parse_text(scanner, false);
+    }
     lexer->result_symbol = T_UNDERLINE;
     return true;
   }

--- a/test/corpus/sections.txt
+++ b/test/corpus/sections.txt
@@ -107,3 +107,18 @@ with whitespaces
    (strong)))
  (section
    (title)))
+
+==================
+Section edge cases
+==================
+
+This is not a section title
+::
+
+  This a block
+
+---
+
+(document 
+  (paragraph)
+  (block_quote (paragraph)))


### PR DESCRIPTION
This fixes an edge case where a blockquote marker on a line just after a
paragraph is seen as an adornment and thus lead to a section being seen.

I found a couple of case in a few library with this.

I think a better fix would be to look back at the title length (is it
possible ? ), or maybe even to require titles to be at least 3 in length
?