### PR TITLE
upstep rust dep to 0.20 and configure for lib build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.17"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,11 +13,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
     c_config.compile("parser");


### PR DESCRIPTION
I want to update the rust dependency to integrate it with [cbfmt](https://github.com/lukas-reineke/cbfmt) (see lukas-reineke/cbfmt#6). 

Will this have impact on neovim-treesitter or can this be merged directly?